### PR TITLE
fix: Return only one response for each request

### DIFF
--- a/packages/cms/lib/modules/vimeo-upload/index.js
+++ b/packages/cms/lib/modules/vimeo-upload/index.js
@@ -61,6 +61,8 @@ module.exports = {
            res.status(500).json({
              error: 'Vimeoconfig not existing'
            });
+           
+           return;
          }
 
          const _clientSecret = vimeoConfig.secret;


### PR DESCRIPTION
This should resolve the 2870 errors we received last week:

```
EXCEPTION
Cannot set headers after they are sent to the client
Problem Id: Error at new NodeError
```