### PR TITLE
Limit body request size in Apostrophe CMS interface

### DIFF
--- a/packages/cms/app.js
+++ b/packages/cms/app.js
@@ -358,7 +358,8 @@ module.exports.getMultiSiteApp = (options) => {
         // if site exists serve it, otherwise give a 404
         if (site) {
             req.site = site;
-            req.allSites = sitesById;
+            // req.allSites = sitesById;
+            req.allSites = { "message": "Hardcoded disabled on purpose, to prevent very large request bodies in the CMS"}
             serveSite(req, res, site, req.forceRestart);
         } else {
             res.status(404).json({error: 'Site not found'});


### PR DESCRIPTION
We got problems with the Web Application Firewall (WAF) which is scanning all incoming requests, because the request-body-size exceeded the max of 2000kB (in fact it was 3,4 MB) when editing webpages using the ApostropheCMS interface - I guess specifically when a 'Resource representation'-widget is on the page.

The request was so large, because the config of all sites was added to the request (I guess via the 'Resource representation'-widget). Looking into git history ([see here](https://github.com/Amsterdam/openstad-frontend/commit/27c1c8fdccb69ea6fa15a7d2d4c3b21ed70d863b)), it looks like this functionality was added to be able to get the slug of idea-detail-pages from other sites, so the user can directly follow a link to their ideas on other sites, from within the 'Mijn account'-page.

As this 'Mijn account'-page is not properly working at the moment anyway, and we would like to enable the WAF again, I'm overwriting the very large 'allSites'-object with a message. In case this change does cause any other issues, this message may help debugging that issue.

See [this related ticket](https://gemeente-amsterdam.atlassian.net/browse/OP-451) for more info.